### PR TITLE
Option to select frascati subjects from Menu Navigation settings

### DIFF
--- a/FrascatiPlugin.php
+++ b/FrascatiPlugin.php
@@ -94,8 +94,9 @@ class FrascatiPlugin extends GenericPlugin
                             PKPApplication::ROUTE_PAGE,
                             null,
                             'search',
-                            'frascati',
-                            [$frascatiBase]
+                            null,
+                            null,
+                            ['frascatiBases' => [$frascatiBase]],
                         ));
                     }
                 });

--- a/FrascatiPlugin.php
+++ b/FrascatiPlugin.php
@@ -13,6 +13,7 @@ namespace APP\plugins\generic\frascati;
 use APP\core\Application;
 use APP\core\Request;
 use PKP\controlledVocab\ControlledVocab;
+use PKP\core\PKPApplication;
 use PKP\plugins\GenericPlugin;
 use PKP\plugins\Hook;
 use Laravel\Scout\Builder;
@@ -54,6 +55,50 @@ class FrascatiPlugin extends GenericPlugin
                 Hook::add('API::vocabs::external', $this->setData(...));
                 Hook::add('Form::config::after', $this->addVocabularyToSubjectsField(...));
                 Hook::add('Submission::validateSubmit', $this->addSubmissionChecks(...));
+
+                // Navigation menu item type for Frascati category links
+                Hook::add('NavigationMenus::itemTypes', function ($hookName, $args) {
+                    $types = &$args[0];
+                    $types['NMI_TYPE_FRASCATI'] = [
+                        'title' => __('plugins.generic.frascati.navMenuItem'),
+                        'description' => __('plugins.generic.frascati.navMenuItem.description'),
+                    ];
+                });
+
+                Hook::add('NavigationMenus::itemCustomTemplates', function ($hookName, $args) {
+                    $templates = &$args[0];
+                    $templates['NMI_TYPE_FRASCATI'] = [
+                        'template' => $this->getTemplateResource('frascatiNMIType.tpl'),
+                    ];
+
+                    $frascatiData = $this->getFrascatiData('en');
+                    $categories = ['' => __('common.chooseOne')];
+                    foreach ($frascatiData as $base) {
+                        $categories[$base['label']] = $base['label'];
+                    }
+                    $templateMgr = TemplateManager::getManager(Application::get()->getRequest());
+                    $templateMgr->assign('frascatiCategories', $categories);
+                });
+
+                Hook::add('NavigationMenus::displaySettings', function ($hookName, $args) {
+                    $nmi = &$args[0];
+                    if ($nmi->getType() !== 'NMI_TYPE_FRASCATI') {
+                        return Hook::CONTINUE;
+                    }
+                    $request = Application::get()->getRequest();
+                    $dispatcher = $request->getDispatcher();
+                    $frascatiBase = $nmi->getPath();
+                    if ($frascatiBase) {
+                        $nmi->setUrl($dispatcher->url(
+                            $request,
+                            PKPApplication::ROUTE_PAGE,
+                            null,
+                            'search',
+                            'frascati',
+                            [$frascatiBase]
+                        ));
+                    }
+                });
             }
 
             if (Config::getVar('search', 'driver') == 'opensearch') {

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -31,3 +31,12 @@ msgstr "The number of required Frascati classifications for a submission (or 0 f
 
 msgid "plugins.generic.frascati.requiredFrascatiClassesNotMet"
 msgstr "Not enough Frascati classifications were specified. At least {$requiredFrascatiClasses} classes are required."
+
+msgid "plugins.generic.frascati.navMenuItem"
+msgstr "Frascati Category"
+
+msgid "plugins.generic.frascati.navMenuItem.description"
+msgstr "A link to search results filtered by a Frascati classification category."
+
+msgid "plugins.generic.frascati.navMenuItem.category"
+msgstr "Frascati Category"

--- a/templates/frascatiNMIType.tpl
+++ b/templates/frascatiNMIType.tpl
@@ -1,0 +1,12 @@
+{**
+ * plugins/generic/frascati/templates/frascatiNMIType.tpl
+ *
+ * Copyright (c) 2024 Public Knowledge Project
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt
+ *
+ * Frascati category navigation menu item type edit form part.
+ *}
+{fbvFormSection id="NMI_TYPE_FRASCATI" class="NMI_TYPE_CUSTOM_EDIT" title="plugins.generic.frascati.navMenuItem.category" for="path" required="true"}
+	{fbvElement type="select" id="path" from=$frascatiCategories selected=$path translate=false}
+{/fbvFormSection}


### PR DESCRIPTION
There is currently no option I could use to point to the search/frascati/base from the navigation option. As we don't have option to attach subpath/query params for internal pages.

This seems like good quick clean solution without changes in the core.

<img width="1483" height="543" alt="Screenshot 2026-02-16 at 12 55 13" src="https://github.com/user-attachments/assets/29f83ef0-1807-48ce-9145-95b3fca2ff4e" />
